### PR TITLE
Use shared participant instead of a literal instance

### DIFF
--- a/src/SuTrafficNode.hpp
+++ b/src/SuTrafficNode.hpp
@@ -55,7 +55,7 @@ private:
 
     struct ParticipantInfo
     {
-        rmf_traffic::schedule::Participant participant;
+        std::shared_ptr<rmf_traffic::schedule::Participant> participant;
         std::shared_ptr<void> negotiation_license;
         ParticipantInfo(rmf_traffic::schedule::Participant p, rmf_traffic_ros2::schedule::Negotiation& negotiation);
     };


### PR DESCRIPTION
I realized there's a very subtle ownership error in the code that gets triggered when the `ParticipantInfo` instance is moved into the map. The memory address of the `ParticipantInfo::participant` field will change, but the `StubbornNegotiator` that was created based on that participant will not be updated to reflect this move. This will lead to undefined behavior, which may explain why the node has not been working.

The changes here depend on [an upstream PR](https://github.com/osrf/rmf_core/pull/298) which has been merged, so you'll need the latest `master` branch of `rmf_core` to compile these changes.